### PR TITLE
Fix stereo issue with different SDR devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Makefile
 linux-bin
 
+/CMakeLists.txt.user

--- a/src/fm/fm-processor.cpp
+++ b/src/fm/fm-processor.cpp
@@ -178,7 +178,7 @@
 	                                     OMEGA_PILOT,
 	                                     25 * omegaDemod,
 	                                     &mySinCos);
-	pilotDelay	= (FFT_SIZE - PILOTFILTER_SIZE) * OMEGA_PILOT;
+	pilotDelay	= (FFT_SIZE - PILOTFILTER_SIZE / 2 - 1) * OMEGA_PILOT;
 	fmAudioFilterActive . store (false);
 
 	rdsDecimator = new newConverter (fmRate, RDS_RATE, fmRate / 1000);
@@ -785,7 +785,7 @@ DSPFLOAT currentPilotPhase = pilotRecover -> getPilotPhase (5 * pilot);
 	   DSPFLOAT PhaseforLRDiff = 2 * (currentPilotPhase + pilotDelay);
 //	Due to filtering the real amplitude of the LRDiff might have
 //	to be adjusted, we guess
-	   DSPFLOAT LRDiff = 2.0 * mySinCos. getCos (PhaseforLRDiff) * demod;
+	   DSPFLOAT LRDiff = 2.0 * mySinCos. getSin (PhaseforLRDiff) * demod;
 	   DSPFLOAT LRPlus = demod;
 	   *audioOut = DSPCOMPLEX (LRPlus, LRDiff);
 	}


### PR DESCRIPTION
Hi Jan,
as mentioned in private emails to you longer ago I still had a stereo issue with my new  SDRPlay RSPdx device that it sounds only like "mono" whereas the DabStick works quite well.

I go on checking this further and I have this pull request  for you where it at least these two devices work well, but the fix sounds reasonable so I expect that other devices will working well, too.

The main change I did was the pilotDelay where the calculation is now regarding the pilot filter pulse center not the whole filter length at all:
- new: `pilotDelay = (FFT_SIZE - PILOTFILTER_SIZE / 2 - 1) * OMEGA_PILOT;`
- old:    `pilotDelay = (FFT_SIZE - PILOTFILTER_SIZE) * OMEGA_PILOT;`

What is not so clear to me, I had also change the mixing phase about 90 degree (at the doubled 38 kHz side) and so I used the sin() instead of the cos() function to do the LRDiff mix.

What could be still a (new) issue: I am not sure if I should shift about +90 or -90 degree. So it could be a minus in front of the sin necessary (or better/faster, shift +/-45 degree (we double later!)  further in pilotDelay. With this issue we would have a swapped L/R channel. Maybe you have a reliable test signal for this?

---
If you want to test my fix with other devices you will find a test branch in my repo:
https://github.com/tomneda/sdr-j-fm/tree/develop/stereo_issue_test

Doing this for a test:
1) Select "S|S" to hear only the sideband signal.
2) Check different stereo broadcast stations as some could have pilot frequency inaccuracy.
3) Check each station with the IQ balance slider whether the signal get minimal at center "0" position

The IQ balance slider adds an artificial phase shift (in degree) to the pilot tone

---

BTW: I wish you this way a happy X-mas and so many health and luck what you can get :-) 

BR 
Thomas
