### PR TITLE
Develop/pss fix

### DIFF
--- a/includes/fm/fm-processor.h
+++ b/includes/fm/fm-processor.h
@@ -272,7 +272,6 @@ private:
 
 	void	process_signal_with_rds (const float,
 	                                 std::complex<float> *,
-	                                 std::complex<float> *,
 	                                 std::complex<float> *);
 //	RDS
 	DSPFLOAT	pilotDelayPSS;

--- a/includes/fm/pilot-recover.h
+++ b/includes/fm/pilot-recover.h
@@ -45,9 +45,7 @@ public:
 	                                             DSPFLOAT iCurMixPhase);
 
 private:
-	fftFilterHilbert	phaseFilter;
 	fftFilter	lpFilter;
-//	fftFilter	lp1Filter;
 	int32_t		rate;
 	int32_t		sampleLockStableCnt;
 	int32_t		sampleUnlockStableCnt;

--- a/src/rds/rds-decoder.cpp
+++ b/src/rds/rds-decoder.cpp
@@ -150,7 +150,7 @@ DSPCOMPLEX r;
 
 	if (my_timeSync. process_sample (v, r)) {
 //	this runs 19000/16 = 1187.5 1/s times
-		r = my_Costas. process_sample (r);
+		//r = my_Costas. process_sample (r);
 	   bool bit	= (real (r) >= 0);
 	   processBit	(bit ^ previousBit, ptyLocale);
 	   previousBit	= bit;

--- a/src/rds/rds-decoder.cpp
+++ b/src/rds/rds-decoder.cpp
@@ -150,7 +150,7 @@ DSPCOMPLEX r;
 
 	if (my_timeSync. process_sample (v, r)) {
 //	this runs 19000/16 = 1187.5 1/s times
-		//r = my_Costas. process_sample (r);
+		r = my_Costas. process_sample (r);
 	   bool bit	= (real (r) >= 0);
 	   processBit	(bit ^ previousBit, ptyLocale);
 	   previousBit	= bit;


### PR DESCRIPTION
Hello Jan,

removing the pilot filter gives a really good channel separation.

But the PSS feature did not work anymore. I could see this best with the DO_STEREO_SEPARATION_TEST "feature" which forces an artificial pilot phase shift which the PSS would compensate normally.

I reconstruct my original version but put some explanation into the code how it works. 

As the spectrum scope and the IQ scope does not show the PSS activity anymore, I also removed the code behind that.

I will write more about that and your last emails later to you.

BR
Thomas