### PR TITLE
Fix "my" RDS2 as it did not work anymore

### DIFF
--- a/forms/radio.ui
+++ b/forms/radio.ui
@@ -1340,7 +1340,7 @@
          <item>
           <widget class="QPushButton" name="btnRestartPSS">
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Restarts the PSS (Perfect Stereo Separation) analyzer&lt;/p&gt;&lt;p&gt;This could be important when the analyzing failed if too little Stereo difference signal was existing while analyzing before (e.g, only a new report without music).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Restarts the PSS (Perfect Stereo Separation) analyzer&lt;/p&gt;&lt;p&gt;This could be important when the analyzing failed if too little Stereo difference signal was existing while analyzing before (e.g, only a news report without music).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string>Restart PSS analyzer</string>
@@ -1625,7 +1625,7 @@
            <item>
             <widget class="QComboBox" name="fmRdsSelector">
              <property name="toolTip">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select RDS decoding:&lt;/p&gt;&lt;p&gt;RDS OFF: RDS is off at all&lt;/p&gt;&lt;p&gt;RDS 1: RDS works with a matched filter recognition based on cuteSDR&lt;br/&gt;&lt;br/&gt;RDS 2: RDS works with Matched Filter contributed by Tomneda&lt;br/&gt;&lt;br/&gt;RDS 2: RDS works with a classic approach of detecting the phases of the RDS signal&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The state, i.e. the setting of the selector, is maintained between program invocations&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select RDS decoding:&lt;/p&gt;&lt;p&gt;RDS OFF: RDS is off at all&lt;/p&gt;&lt;p&gt;RDS 1: RDS works with a matched filter recognition based on cuteSDR&lt;br/&gt;&lt;br/&gt;RDS 2: RDS works with matched Filter and M&amp;amp;M time synchronizer contributed by Tomneda&lt;br/&gt;&lt;br/&gt;RDS 3: RDS works with a classic approach of detecting the phases of the RDS signal&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The state, i.e. the setting of the selector, is maintained between program invocations&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <item>
               <property name="text">

--- a/includes/rds/rds-decoder.h
+++ b/includes/rds/rds-decoder.h
@@ -44,6 +44,7 @@
 #include	"rds-blocksynchronizer.h"
 #include	"rds-groupdecoder.h"
 #include	"costas.h"
+#include	"agc.h"
 
 class RadioInterface;
 class	rdsDecoder_1;
@@ -60,7 +61,7 @@ public:
 	   RDS_OFF,
 		RDS_1,
 		RDS_2,
-	        RDS_3
+		RDS_3
 	};
 
 	bool	doDecode	(const DSPCOMPLEX,
@@ -72,6 +73,7 @@ private:
 	RDSGroup		my_rdsGroup;
 	rdsGroupDecoder		my_rdsGroupDecoder;
 	rdsBlockSynchronizer	my_rdsBlockSync;
+	AGC				my_AGC;
 	Costas			my_costas;
 	rdsDecoder_1		*decoder_1;
 	rdsDecoder_2		*decoder_2;

--- a/includes/various/costas.h
+++ b/includes/various/costas.h
@@ -19,6 +19,10 @@ public:
 
 inline
 	DSPCOMPLEX process_sample (const DSPCOMPLEX z) {
+	#ifdef DO_STEREO_SEPARATION_TEST
+	   return z; // do nothing here
+	#endif   
+	
 	   const DSPCOMPLEX r	= z * std::exp (DSPCOMPLEX (0, -phase));
 	   const float error	= real (r) * imag (r);
 

--- a/src/fm/fm-processor.cpp
+++ b/src/fm/fm-processor.cpp
@@ -756,7 +756,7 @@ void	fmProcessor::process_signal_with_rds (const float demod,
 	   float rdsBaseBp	= rdsBandPassFilter. Pass (demod);
 	   std::complex<float> rdsBaseHilb =
 	                          rdsHilbertFilter. Pass (rdsBaseBp);
-	   float thePhase	= 3 * rdsPhaseBuffer [rdsPhaseIndex];
+	   float thePhase	= 3 * (rdsPhaseBuffer [rdsPhaseIndex] + PILOTTESTDELAY);
 	   rdsPhaseBuffer [rdsPhaseIndex]	= currentPilotPhase;
 	   rdsPhaseIndex	= (rdsPhaseIndex + 1) % RDS_SAMPLE_DELAY;
 //

--- a/src/rds/ebu-codetables.c
+++ b/src/rds/ebu-codetables.c
@@ -36,9 +36,6 @@ const char * const pty_table[][2] = {
   {"Alarm",                 "Emergency"}
 };
 
-uint16_t pty_locale = 0;
-// set to 0 for Europe (1 for USA) which will use first column instead
-
 
 //	mapping from EBU code tables to 16 bit codes for QChar
 
@@ -62,8 +59,10 @@ const uint16_t EBU_E1[16][14] = {
 };
 
 uint16_t mapEBUtoUnicode(uint8_t alfabet, uint8_t character) {
-uint8_t columnnibble = (character & 0xF0) >> 4;
-uint8_t rownibble = character & 0x0F;
+int8_t columnnibble = ((character & 0xF0) >> 4) - 2;
+int8_t rownibble = character & 0x0F;
 	(void)alfabet;
-	return EBU_E1 [rownibble][columnnibble - 2];
+   if (columnnibble < 0)
+      return ' '; // e.g. when END_OF_RADIO_TEXT is received
+	return EBU_E1 [rownibble][columnnibble];
 }

--- a/src/rds/rds-decoder-1.cpp
+++ b/src/rds/rds-decoder-1.cpp
@@ -36,9 +36,6 @@
  *	RDS is a bpsk-like signal, with a baudrate 1187.5
  *	on a carrier of  3 * 19 k.
  *	48 cycles per bit, 1187.5 bits per second.
- *	With a reduced sample rate of 19k this would mean
- *	19000 / 1187.5 samples per bit, i.e. 16
- *	samples per bit.
  */
 
 	rdsDecoder_1::rdsDecoder_1 (RadioInterface	*myRadio,
@@ -71,12 +68,7 @@ float	synchronizerSamples;
 	rdsKernel. resize (rdsBufferSize);
 	rdsKernel [length]	= 0;
 //
-//	
-//	While the original samplerate (24000) gave a perfect match,
-//	the samplerate as changed by Tomneda (19000) gave 4 "inf"
-//	values (that is probably why tomneda was not content with
-//	the results of the match).
-//	To catch the inf values, I at first dded an "isinf" test, 
+//	To catch the inf values, I at first addded an "isinf" test, 
 //	this "isinf" check  was with the "fast math" option
 //	in the "pro" file disregarded.
 //	Anyway, a minor mod in the formula, changing 64 to 64.01, solved

--- a/src/rds/rds-decoder-3.cpp
+++ b/src/rds/rds-decoder-3.cpp
@@ -37,9 +37,6 @@
  *	RDS is a bpsk-like signal, with a baudrate 1187.5
  *	on a carrier of  3 * 19 k.
  *	48 cycles per bit, 1187.5 bits per second.
- *	With a reduced sample rate of 19k this would mean
- *	19000 / 1187.5 samples per bit, i.e. 16
- *	samples per bit.
  */
 	rdsDecoder_3::rdsDecoder_3 (RadioInterface	*myRadio,
 	                            int32_t             rate,

--- a/src/rds/rds-decoder.cpp
+++ b/src/rds/rds-decoder.cpp
@@ -37,6 +37,7 @@
 	                        int32_t		rate):
 	                            my_rdsBlockSync (myRadioInterface),
 	                            my_rdsGroupDecoder (myRadioInterface),
+	                            my_AGC (2e-3f, 0.38f, 9.0f),	
 	                            my_costas (rate, 1.0f / 16.0f,
 	                                            0.02f/16.0f, 10.0f) {
 	decoder_1	= new rdsDecoder_1 (myRadioInterface, rate);
@@ -68,15 +69,14 @@ void	rdsDecoder::reset () {
 bool	rdsDecoder::doDecode (DSPCOMPLEX v,
 	                      DSPCOMPLEX *m,
 	                      ERdsMode  mode, int ptyLocale) {
-// this is called typ. 19000 1/s
-DSPCOMPLEX r;
+// this is called typ. 24000 1/s
 bool	b;
 uint8_t	theBit;
 
-	v	= my_costas. process_sample (v);
 	switch (mode) {
 	   case rdsDecoder::ERdsMode::RDS_1:
-	      *m =  v * 4.0f;
+	      v = my_costas. process_sample (v);
+	      *m = my_AGC. process_sample(v);
 	      b = decoder_1 -> doDecode (real (v), &theBit);
 	      if (b)
 	         processBit (theBit, ptyLocale);
@@ -89,7 +89,8 @@ uint8_t	theBit;
 	      return b;
 
 	   case rdsDecoder::ERdsMode::RDS_3:
-	      *m = v * 4.0f;
+	      v = my_costas. process_sample (v);
+	      *m = my_AGC. process_sample(v);
 	      b = decoder_3 -> doDecode (real (v), &theBit);
 	      if (b)
 	         processBit (theBit, ptyLocale);


### PR DESCRIPTION
After your vastly rebuild of the code and the change to 24000 sample rate of the RDS my RDS2 was not working anymore.
So I could get it run again without many needed changes.

Beside that I did following things, but there are all minor and should not be complicated to integrate:
- remove not (more) valid comments
- fix typos and add text in GUI
- add AGC to IQ scope for RDS1 and RDS3 to be better comparable to RDS2
- fix usage of switch DO_STEREO_SEPARATION_TEST
- fix overflow issue in ebu-codetables.c  as there is still one of the issue from Andrew left (see the last S with apostrophe here):
![failure_in_RDS](https://user-images.githubusercontent.com/103888527/219970127-9dc33e6e-7173-433c-b9f9-da6dffaffe9d.png)

I want to say something about your changes and comments in the code and found also a new issue but I will do that in a private mail. 