### PR TITLE
Remaining things after refining

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ linux-bin
 /CMakeLists.txt.user
 /fmreceiver.pro.user
 /build*
+/.vscode
+/.idea
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ The version number is now 3.15
 
 ![fm receiver](/fm-mainwidget.png?raw=true)
 
-New is a so-called PSS (perfect stereo sound) control on the main widget,
+New is a so-called PSS (perfect stereo separation) control on the main widget,
 contributed by TomNeda.
 
 In computing the 38 Khz signal to decode the L-R signal, from the 19
 KHz pilot signal, an error may occur, an offset of a few Hz.
 The PSS algorithm applies some techniques to figure out what
 correction on the recomputed
-39 KHz carrier that has to be applied for a perfect match.
+38 KHz carrier that has to be applied for a perfect match.
 
 While in previous versions the list of configure devices was
 checked on program start up, to find an attacted device, the

--- a/fmreceiver.pro
+++ b/fmreceiver.pro
@@ -26,6 +26,12 @@ QMAKE_CXXFLAGS	+= -isystem $$[QT_INSTALL_HEADERS]
 RC_ICONS        =  fm-icon.ico
 RESOURCES       += resources.qrc
 
+# Stereo sideband test (after activating compile switch DO_STEREO_SEPARATION_TEST)
+# Select "T|T" to hear the ortogonal demodulated sideband signal
+# Check different station with the IQ balance slider whether the signal get minimal at center "0" position
+# You can also see in the RDS IQ scope the current phase on the 38 khz carrier (Costas Loop for RDS decoding is also switched off)
+# DEFINES += DO_STEREO_SEPARATION_TEST
+
 TRANSLATIONS = i18n/de_DE.ts i18n/it_IT.ts i18n/hu_HU.ts
 
 DEPENDPATH += . \

--- a/forms/radio.ui
+++ b/forms/radio.ui
@@ -1625,7 +1625,7 @@
            <item>
             <widget class="QComboBox" name="fmRdsSelector">
              <property name="toolTip">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select RDS decoding:&lt;/p&gt;&lt;p&gt;RDS OFF: RDS is off at all&lt;/p&gt;&lt;p&gt;RDS 1: RDS works with a matched filter recognition based on cuteSDR&lt;br/&gt;&lt;br/&gt;RDS 2: RDS-2 works with matched Filter and time synchronizer contributed by Tomneda&lt;br/&gt;&lt;br/&gt;RDS 2: RDS works with a classic approach of detecting the phases of the RDS signal&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The state, i.e. the setting of the selector, is maintained between program invocations&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select RDS decoding:&lt;/p&gt;&lt;p&gt;RDS OFF: RDS is off at all&lt;/p&gt;&lt;p&gt;RDS 1: RDS works with a matched filter recognition based on cuteSDR&lt;br/&gt;&lt;br/&gt;RDS 2: RDS-2 works with matched Filter and time synchronizer contributed by Tomneda&lt;br/&gt;&lt;br/&gt;RDS 3: RDS works with a classic approach of detecting the phases of the RDS signal&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The state, i.e. the setting of the selector, is maintained between program invocations&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <item>
               <property name="text">

--- a/includes/fm-constants.h
+++ b/includes/fm-constants.h
@@ -34,13 +34,6 @@
 #define	QT_STATIC_CONST
 
 #define	INPUT_RATE	2304000
-/*
- * Stereo sideband test (after activating compile switch DO_STEREO_SEPARATION_TEST)
- * 1) Select "T|T" to hear the ortogonal demodulated sideband signal
- * 2) Check different station with the IQ balance slider whether the signal get minimal at center "0" position
- * 3) You can also see in the RDS IQ scope the remaing phase (Costas Loop is switched off)
-*/
-#define	DO_STEREO_SEPARATION_TEST
 
 #ifndef __FREEBSD__
 #include	<malloc.h>

--- a/includes/scopes-qwt6/ls-scope.h
+++ b/includes/scopes-qwt6/ls-scope.h
@@ -61,7 +61,7 @@ private:
 	void		mapSpectrum (std::complex<float> *in,
                                      bool     showFull,
                                      double *const out,
-                                     int32_t ioZoomFactor);
+                                     int & ioZoomFactor);
 
 	int		averageCount;
 	int		displaySize;

--- a/includes/various/costas.h
+++ b/includes/various/costas.h
@@ -19,6 +19,10 @@ public:
 
 inline
 	DSPCOMPLEX process_sample (const DSPCOMPLEX z) {
+	#ifdef DO_STEREO_SEPARATION_TEST
+	   return z; // do nothing here
+	#endif   
+	
 	   const DSPCOMPLEX r	= z * std::exp (DSPCOMPLEX (0, -phase));
 	   const float error	= real (r) * imag (r);
 

--- a/radio.cpp
+++ b/radio.cpp
@@ -1011,8 +1011,8 @@ int16_t bl, br;
 #else
 	bl		= 100 - n;
 	br		= 100 + n;
-	attValueL	= currAttSliderValue * (float)bl / 100;
-	attValueR	= currAttSliderValue * (float)br / 100;
+	attValueL	= (float)bl / 100;
+	attValueR	= (float)br / 100;
 	if (myFMprocessor != nullptr)
 	   myFMprocessor	-> setAttenuation (attValueL, attValueR);
 #endif

--- a/radio.h
+++ b/radio.h
@@ -122,7 +122,6 @@ private:
 
 	uint8_t		HFviewMode;
 	uint8_t		inputMode;
-	int16_t		currAttSliderValue;
 	float		attValueL;
 	float		attValueR;
 

--- a/src/fm/fm-processor.cpp
+++ b/src/fm/fm-processor.cpp
@@ -107,8 +107,8 @@
 	this	-> lfBuffer		= lfBuffer;
 	this	-> thresHold		= thresHold;
 	this	-> scanning		= false;
-	this	-> Lgain		= 20;
-	this	-> Rgain		= 20;
+	this	-> Lgain		= 1;
+	this	-> Rgain		= 1;
 
 	this	-> lowPassFrequency	= 15000;
 	this	-> newAudioFilter. store (false);
@@ -605,8 +605,7 @@ int		iqCounter	= 0;
 	            spectrumBuffer_lf. push_back (std::complex<float> (0, 0));
 	            break;
 	         case ELfPlot::IF_FILTERED:
-	            // TODO: somehow the IF level got much higher, reduce level here for the scope
-	            spectrumBuffer_lf. push_back (v * 0.05f);
+	            spectrumBuffer_lf. push_back (v);
 	            break;
 	         case ELfPlot::DEMODULATOR:
 	            spectrumBuffer_lf. push_back (demod);
@@ -861,7 +860,7 @@ void	fmProcessor::triggerFrequencyChange() {
 
 void	fmProcessor::restartPssAnalyzer	() {
 	pilotDelayPSS = 0;
-	pPSS. reset (); // TODO shift this as it is called while RDS switch, too
+	pPSS. reset ();
 }
 
 void	fmProcessor::resetRds	() {

--- a/src/scopes-qwt6/ls-scope.cpp
+++ b/src/scopes-qwt6/ls-scope.cpp
@@ -109,12 +109,12 @@ double Y_values [displaySize];
 	   for (int i = 0; i < displaySize; i++) {
 	      X_axis [i] =
 	            (-(sampleRate / 2.0) + (2 * i * temp)) /
-	                           ((double)Khz(1)); // two side spectrum
+	                           ((double)Khz(1)) / zoomFactor; // two side spectrum
 	   }
 	}
 	else {
 	   for (int i = 0; i < displaySize; i++) {
-	      X_axis [i] = (i * temp) / ((double)Khz (1)); // one-side spectrum
+	      X_axis [i] = (i * temp) / ((double)Khz (1)) / zoomFactor; // one-side spectrum
 	   }
 	}
 
@@ -130,8 +130,11 @@ double Y_values [displaySize];
 void	ls_scope::mapSpectrum (std::complex<float> *in,
 	                       bool	showFull,
 	                       double	*out,
-	                       int	ioZoomFactor) {
+	                       int	& ioZoomFactor) {
 int16_t factor = spectrumSize / displaySize;  // typ factor = 4 (whole divider)
+
+	if (!showFull)	
+	   factor /= 2;
 
 	if (factor / ioZoomFactor >= 1) {
 	   factor /= ioZoomFactor;
@@ -159,7 +162,6 @@ int16_t factor = spectrumSize / displaySize;  // typ factor = 4 (whole divider)
 	   }
 	}
 	else {		// half
-	   factor /= 2;
 	   for (int32_t i = 0; i < displaySize; i++) {
 	      double f = 0;
 //	read 0Hz to rate / 2 -> map to mid to end of display


### PR DESCRIPTION
There are still some things left on the master which come from the refactoring (can happen when changing hundred of lines) and other very tiny changes:

- The zoom factor did not change the x-axis values.
- A not allowed zoom factor (4 at half side view) led to a "division by zero" (ls-scope.cpp:169).
- Small correction in README.md and radio.ui.
- Add excludes to .gitignore for VSCode and JetBrains IDE users (like me :-), beside QTCreator ).
- I move the compiler switch DO_STEREO_SEPARATION_TEST (not activated) to fmreceiver.pro (CMakeFiles.txt may follow if needed).
- An initialization issue which meanwhile are longer in the code (since https://github.com/JvanKatwijk/sdr-j-fm/commit/32768773cb70b18368c3390906be9ea0792f140c#diff-017ed302f9eb902069c2e9247a3eab6f556f78c0cd9a2eaeda0f6c2be123ee3aL1009 ): the member "currAttSliderValue" was not more initialized. This doesn't matter unless the IQ balance slider was not touched. In the current AppImage the compiler switch DO_STEREO_SEPARATION_TEST is activated (was that deliberately?) so the IQ balance slider did not use the not initialized member and no problem happens.

The fixes above would not change important things (or show no effects) in the current AppImage or Windows setup. So they need not to be rebuild (imo). But it would be good (gives me a better feeling :-) ) if they are on the mainline.